### PR TITLE
fix: missing exceptions making tests to fail

### DIFF
--- a/.github/workflow/ci.yaml
+++ b/.github/workflow/ci.yaml
@@ -1,0 +1,26 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install requirements
+        run: pip install -r requirements.txt -r requirements_dev.txt
+
+      - name: Run pytest
+        # Run tox using the version of Python in `PATH`
+        run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-solidpython2==2.0.2
 cadquery==2.3.1
 cadquery-ocp==7.7.0
+pyinotify==0.9.6
+solidpython2==2.0.2
 trimesh==3.22.3

--- a/solid_node/exceptions.py
+++ b/solid_node/exceptions.py
@@ -1,0 +1,6 @@
+class MeshNotRendered(Exception):
+    pass
+
+
+class NonRigidSolid(Exception):
+    pass


### PR DESCRIPTION
Tests were failing without the Exceptions and pyinotify deps defined in this PR.

These are the error messages before this PR
```
ImportError while importing test module '/home/fabio/devel/solid_node/tests/test_scad_stl.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_scad_stl.py:5: in <module>
    from .base import BaseNodeTest, preserve
tests/base.py:5: in <module>
    from solid_node.node import StlRenderStart
solid_node/node/__init__.py:9: in <module>
    from .cq_node import CadQueryNode
solid_node/node/cq_node.py:5: in <module>
    from .leaf import LeafNode
solid_node/node/leaf.py:2: in <module>
    from .spatial import SpatialNodeMixin
solid_node/node/spatial.py:5: in <module>
    from solid_node.exceptions import MeshNotRendered, NonRigidSolid
E   ModuleNotFoundError: No module named 'solid_node.exceptions'
```

```
ImportError while importing test module '/home/fabio/devel/solid_node/tests/test_scad_stl.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_scad_stl.py:5: in <module>
    from .base import BaseNodeTest, preserve
tests/base.py:5: in <module>
    from solid_node.node import StlRenderStart
solid_node/node/__init__.py:7: in <module>
    from .base import StlRenderStart
solid_node/node/base.py:6: in <module>
    import pyinotify
E   ModuleNotFoundError: No module named 'pyinotify'
```