### PR TITLE
feat: add github actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,149 @@
+name: Python application
+
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: List changed python files
+        id: list_changed_python_files
+        run: |
+          git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin main
+          files="$(git diff --name-only --diff-filter=AM origin/main | grep '.py$' | tr '\n' ' ')"
+          if [ -n "${files}" ]; then
+            echo "files=${files}" | tee >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - uses: actions/cache@v3
+        id: cache-primes
+        with:
+          path: venv
+          key: venv-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt') }}
+
+      - name: Install requirements
+        if: steps.cache-primes.outputs.cache-hit != 'true'
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements_dev.txt
+
+      - name: Black
+        if: steps.list_changed_python_files.outputs.files != null
+        run: |
+          . venv/bin/activate
+          black --check ${{ steps.list_changed_python_files.outputs.files }}
+
+      - name: Flake8
+        if: steps.list_changed_python_files.outputs.files != null
+        run: |
+          . venv/bin/activate
+          flake8 --max-line-length=89  ${{ steps.list_changed_python_files.outputs.files }}
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: openscad
+          version: 1.0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - uses: actions/cache@v3
+        id: cache-primes
+        with:
+          path: venv
+          key: venv-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt') }}
+
+      - name: Install requirements
+        if: steps.cache-primes.outputs.cache-hit != 'true'
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements_dev.txt
+
+      - name: Run tests
+        run: |
+          . venv/bin/activate
+          coverage run --source solid_node -m pytest
+          coverage report -m
+
+  build:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: write
+
+    env:
+      SOLID_NODE_VERSION: "${{ github.ref_name }}"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Detect package version
+        id: package_version
+        run: |
+          from os import getenv as env
+          from setuptools.extern.packaging.version import parse
+          solid_node_version = str(parse(env("SOLID_NODE_VERSION")))
+          print(f"version={solid_node_version}", file=open(env("GITHUB_OUTPUT"), "a"), flush=True)
+        shell: python
+
+      - uses: actions/cache@v3
+        id: cache-primes
+        with:
+          path: venv
+          key: venv-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements*.txt') }}
+
+      - name: Install requirements
+        if: steps.cache-primes.outputs.cache-hit != 'true'
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements_dev.txt
+
+      - name: Build python package
+        run: |
+          . venv/bin/activate
+          make dist
+
+      - name: Create release
+        if: steps.package_version.outputs.version != null
+        run: |
+          gh release create ${{ steps.package_version.outputs.version }} ./dist/* --repo="$GITHUB_REPOSITORY"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add GitHub workflows to run linter and tests on push. Additionally, there is a job to build and publish release files in the GitHub releases page. To get release on tag to work, it is necessary to allow writing permission for the GITHUB_TOKEN. This can be done by 

1. go to the [project settings](https://github.com/LibreSolid/solid_node/settings)
2. click in **Actions**
3. then **General**
4. enable the radio button called **Read and write permissions**

